### PR TITLE
Fix path drawing and reorg project to match the article

### DIFF
--- a/Drawing Performance.xcodeproj/project.pbxproj
+++ b/Drawing Performance.xcodeproj/project.pbxproj
@@ -106,8 +106,8 @@
 			children = (
 				283AF43921EB994B0006DFCB /* FreeDrawingImageViewCPUSlow.swift */,
 				283AF43B21EB994B0006DFCB /* FreeDrawingImageViewCPUFast.swift */,
-				283AF44F21EBB4EF0006DFCB /* FreeDrawingImageViewDrawLayer.swift */,
 				283AF43A21EB994B0006DFCB /* FreeDrawingImageViewSubLayer.swift */,
+				283AF44F21EBB4EF0006DFCB /* FreeDrawingImageViewDrawLayer.swift */,
 			);
 			path = "Drawing Views";
 			sourceTree = "<group>";

--- a/Drawing Performance/Drawing Views/FreeDrawingImageViewCPUFast.swift
+++ b/Drawing Performance/Drawing Views/FreeDrawingImageViewCPUFast.swift
@@ -48,6 +48,7 @@ class FreedrawingImageViewDrawRect: UIView, Drawable {
         context.setStrokeColor(lineColor.cgColor)
         context.setLineWidth(lineWidth)
         context.setLineCap(.round)
+        context.setLineJoin(.round)
         
         for (index, point) in line.enumerated() {
             if index == 0 {

--- a/Drawing Performance/Drawing Views/FreeDrawingImageViewDrawLayer.swift
+++ b/Drawing Performance/Drawing Views/FreeDrawingImageViewDrawLayer.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-// Slow GPU
+// Draw GPU
 class FreeDrawingImageViewDrawLayer: UIView, Drawable {
     
     var drawingLayer: CAShapeLayer?

--- a/Drawing Performance/Drawing Views/FreeDrawingImageViewDrawLayer.swift
+++ b/Drawing Performance/Drawing Views/FreeDrawingImageViewDrawLayer.swift
@@ -56,6 +56,7 @@ class FreeDrawingImageViewDrawLayer: UIView, Drawable {
         drawingLayer.opacity = 1
         drawingLayer.lineWidth = lineWidth
         drawingLayer.lineCap = .round
+        drawingLayer.lineJoin = .round
         drawingLayer.fillColor = UIColor.clear.cgColor
         drawingLayer.strokeColor = lineColor.cgColor
         

--- a/Drawing Performance/Drawing Views/FreeDrawingImageViewSubLayer.swift
+++ b/Drawing Performance/Drawing Views/FreeDrawingImageViewSubLayer.swift
@@ -7,8 +7,8 @@
 
 import UIKit
 
-// Fast GPU
-class FreedrawingImageView: UIImageView, Drawable {
+// Sublayer GPU
+class FreeDrawingImageViewSubLayer: UIImageView, Drawable {
     
     var spiralPoints = [CGPoint]()
     var currentTouchPosition: CGPoint?

--- a/Drawing Performance/ViewController.swift
+++ b/Drawing Performance/ViewController.swift
@@ -18,8 +18,8 @@ class ViewController: UIViewController {
     
     lazy var cpuSlowView: FreedrawingImageViewCG = setupView()
     lazy var cpuFastView: FreedrawingImageViewDrawRect = setupView()
+    lazy var gpuSubLayer: FreeDrawingImageViewSubLayer = setupView()
     lazy var gpuDrawLayer: FreeDrawingImageViewDrawLayer = setupView()
-    lazy var gpuSubLayer: FreedrawingImageView = setupView()
     
     lazy var allViews: [Drawable] = [cpuSlowView, cpuFastView, gpuDrawLayer, gpuSubLayer]
     
@@ -37,8 +37,8 @@ class ViewController: UIViewController {
         super.viewDidAppear(animated)
         cpuSlowView.backgroundColor = .green
         cpuFastView.backgroundColor = .blue
-        gpuDrawLayer.backgroundColor = .orange
         gpuSubLayer.backgroundColor = .purple
+        gpuDrawLayer.backgroundColor = .orange
         
         displayedView = .cpuSlow(cpuSlowView)
     }
@@ -59,8 +59,9 @@ class ViewController: UIViewController {
         switch sender.selectedSegmentIndex {
         case 0: displayedView = .cpuSlow(cpuSlowView)
         case 1: displayedView = .cpuFast(cpuFastView)
-        case 2: displayedView = .gpuDrawLayer(gpuSubLayer)
-        case 3: displayedView = .gpuSubLayer(gpuDrawLayer)
+        case 2: displayedView = .gpuSubLayer(gpuSubLayer)
+        case 3: displayedView = .gpuDrawLayer(gpuDrawLayer)
+            
         default: break
         }
     }


### PR DESCRIPTION
Thanks for the awesome repo!

Here's 2 fixes for some issues I found when going through the examples.

- Fix naming/ordering of GPU approaches to be in sync with the article.
- Fix drawing glitches by leveraging `lineJoin` in CPU fast and GPU draw approaches.

The following glitches (visual artifacts due to the lines not being rounded) occurred in both of these approaches when trying to do shading gestures.
![Simulator Screen Shot - iPhone Xs - 2019-08-08 at 17 34 50](https://user-images.githubusercontent.com/1663696/62742173-8d53d980-ba0b-11e9-8058-f44550c7a57a.png)
